### PR TITLE
Adds rego rule for read write default in access rules

### DIFF
--- a/rules/002_domain_model/002_0008_avoid_read_write_default_access_rule.rego
+++ b/rules/002_domain_model/002_0008_avoid_read_write_default_access_rule.rego
@@ -1,0 +1,44 @@
+# METADATA
+# scope: package
+# title: Avoid using default read write access
+# description: This can lead to wrong set access rights
+# authors:
+# - Jurre Tanja <jurre.tanja@mendix.com>
+# custom:
+#  category: Maintainability
+#  rulename: AvoidDefaultReadWriteAccess
+#  severity: MEDIUM
+#  rulenumber: 002_0008
+#  remediation: Set default access rights to Read only or None.
+#  input: .*/DomainModels\$DomainModel\.yaml
+package app.mendix.domain_model.avoind_default_readwrite_access
+
+import rego.v1
+
+annotation := rego.metadata.chain()[1].annotations
+
+default allow := false
+
+allow if count(errors) == 0
+
+errors contains error if {
+	entity := input.Entities[_]
+	entity_name := entity.Name
+	roles := entity.AccessRules[_].AllowedModuleRoles
+	role_names := [name | role := roles[_]; parts := split(role, "."); name := parts[count(parts) - 1]]
+	roles_list := concat(", ", role_names)
+
+	# Check for ReadWrite access
+	entity.AccessRules[_].DefaultMemberAccessRights == "ReadWrite"
+
+	error := sprintf(
+		"[%v, %v, %v] ReadWrite access rules found in entity %v for roles %v",
+		[
+			annotation.custom.severity,
+			annotation.custom.category,
+			annotation.custom.rulenumber,
+			entity_name,
+			roles_list,
+		],
+	)
+}

--- a/rules/002_domain_model/002_0008_avoid_read_write_default_access_rule_test.yaml
+++ b/rules/002_domain_model/002_0008_avoid_read_write_default_access_rule_test.yaml
@@ -1,0 +1,43 @@
+TestCases:
+  - name: allow readonly access
+    allow: true
+    input:
+      Entities:
+        - $Type: DomainModels$EntityImpl
+          Name: Entity1
+          AccessRules:
+            - $Type: DomainModels$AccessRule
+              AllowCreate: false
+              AllowDelete: false
+              AllowedModuleRoles:
+                - MyFirstModule.User
+                - MyFirstModule.Admin
+              DefaultMemberAccessRights: ReadOnly
+  - name: allow none access
+    allow: true
+    input:
+      Entities:
+        - $Type: DomainModels$EntityImpl
+          Name: Entity2
+          AccessRules:
+            - $Type: DomainModels$AccessRule
+              AllowCreate: false
+              AllowDelete: false
+              AllowedModuleRoles:
+                - MyFirstModule.User
+                - MyFirstModule.Admin
+              DefaultMemberAccessRights: None
+  - name: do not allow readwrite access
+    allow: false
+    input:
+      Entities:
+        - $Type: DomainModels$EntityImpl
+          Name: Entity3
+          AccessRules:
+            - $Type: DomainModels$AccessRule
+              AllowCreate: false
+              AllowDelete: false
+              AllowedModuleRoles:
+                - MyFirstModule.User
+                - MyFirstModule.Admin
+              DefaultMemberAccessRights: ReadWrite


### PR DESCRIPTION
The least privilege principle states that users only need those rights that they have access to and should be granted more rights than necessary. Setting the default rights for new members (attributes) to Read/Write violates this principle and make your application less secure if this is not considered carefully.